### PR TITLE
Fix hellomello instructions compile error

### DIFF
--- a/jni_hello.nim
+++ b/jni_hello.nim
@@ -10,7 +10,7 @@ import src / dali
 
 const
   Activity = "Landroid/app/Activity;"
-  HelloActivity = "Lcom/akavel/hello2/HelloActivity;"
+  HelloActivity = "Lcom/akavel/hello2/HelloActivity;"Just gave hellomello a quick whirl. 
   Bundle = "Landroid/os/Bundle;"
   TextView = "Landroid/widget/TextView;"
   System = "Ljava/lang/System;"
@@ -31,7 +31,7 @@ dex.classes.add:
     proc `<init>`() {.public, constructor, regs:1, ins:1, outs:1.} =
       invoke_direct(0, jproto Activity.`<init>`())
       return_void()
-    proc onCreate(Bundle) {.public, regs:4, ins:2, outs:2.} =
+    proc onCreate(_: Bundle) {.public, regs:4, ins:2, outs:2.} =
       # ins: this, arg0
       # super.onCreate(arg0)
       invoke_super(2, 3, jproto Activity.onCreate(Bundle))


### PR DESCRIPTION
The original version gave me

    $ nim c jni_hello.nim
    jni_hello.nim(34, 19) Error: missing type for param

But following the example from the tests I made the change and now it works.